### PR TITLE
Get encoding from msg in `ImageConverterNode::ROS1To2Callback`

### DIFF
--- a/isaac_ros_nitros_bridge_ros2/src/image_converter_node.cpp
+++ b/isaac_ros_nitros_bridge_ros2/src/image_converter_node.cpp
@@ -143,7 +143,7 @@ void ImageConverterNode::ROS1To2Callback(
   nvidia::isaac_ros::nitros::NitrosImage nitros_image =
     nvidia::isaac_ros::nitros::NitrosImageBuilder()
     .WithHeader(msg->header)
-    .WithEncoding(img_encodings::RGB8)
+    .WithEncoding(msg->encoding)
     .WithDimensions(msg->height, msg->width)
     .WithGpuData(reinterpret_cast<void *>(gpu_buffer))
     .Build();


### PR DESCRIPTION
Our ros1 cam driver stack produces images in BGR, we could reencode them to RGB before sending over the nitros bridge but ideally the `image_converter_node` handles this implicitly.